### PR TITLE
require signing only when publishing remotely

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,14 @@ publishing {
     }
 }
 
+val isReleaseVersion = !version.toString().endsWith("-SNAPSHOT")
+
 signing {
+    setRequired {
+        // signing is required if this is a release version and the artifacts are to be published
+        isReleaseVersion && gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
+    }
+
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
This commit unblocks usage of publishToMavenLocal task in pre-merge check for external pull requests without exposing signing username/password.